### PR TITLE
Fix #19 - back button navigation issue

### DIFF
--- a/src/lib/Timer.svelte
+++ b/src/lib/Timer.svelte
@@ -35,6 +35,7 @@
     let elapsed = 0
 
     function toggleTimer(solve) {
+        clearInterval(timerId)
         if (solve.startedAt === -1) {return}
         if (solve.elapsedTime === -1) {
             elapsed = (new Date()).valueOf() - solve.startedAt

--- a/src/lib/puzzle/Puzzle.svelte
+++ b/src/lib/puzzle/Puzzle.svelte
@@ -12,6 +12,13 @@
     export let tiles = []
     export let wrap = false
     export let savedProgress
+    export let progressStoreName = ''
+
+    // Remember the name that the puzzle was created with
+    // to prevent accidental saving to another puzzle's progress
+    // if a user navigates between puzzles directly via back/forward buttons
+    const myProgressName = progressStoreName
+
     let svgWidth = 500
     let svgHeight = 500
 
@@ -47,7 +54,6 @@
 
     onDestroy(()=>{
         // save progress immediately if navigating away (?)
-        // console.log('clear timer because destroy')
         save.clear()
         if (!$solved) {save.now()}
     })
@@ -78,7 +84,7 @@
         if ($solved) {
             return
         }
-        const data = game.tileStates.map(tile => {
+        const tileStates = game.tileStates.map(tile => {
             const data = tile.data
             return {
                 rotations: data.rotations,
@@ -87,7 +93,12 @@
                 edgeMarks: data.edgeMarks,
             }
         })
-        dispatch('progress', {tiles: data})
+        dispatch('progress', {
+            name: myProgressName,
+            data: {
+                tiles: tileStates,
+            },
+        })
     }
 
     const save = createThrottle(saveProgress, 3000)

--- a/src/routes/hexagonal-wrap/[size=integer]/[id=integer].svelte
+++ b/src/routes/hexagonal-wrap/[size=integer]/[id=integer].svelte
@@ -103,8 +103,9 @@
     window.localStorage.removeItem(progressStoreName)
   }
   function saveProgress(event) {
-    const data = JSON.stringify(event.detail)
-    window.localStorage.setItem(progressStoreName, data)
+    const {data, name} = event.detail
+    const dataStr = JSON.stringify(data)
+    window.localStorage.setItem(name, dataStr)
   }
 </script>
 
@@ -126,6 +127,7 @@
 
 {#key $page.params}
   <Puzzle {width} {height} {tiles} {savedProgress} wrap={true}
+     {progressStoreName}
      on:solved={stop}
      on:initialized={start}
      on:progress={saveProgress}

--- a/src/routes/hexagonal-wrap/[size=integer]/index.svelte
+++ b/src/routes/hexagonal-wrap/[size=integer]/index.svelte
@@ -10,7 +10,7 @@
       const size = $page.params.size
       solves = getSolves($page.url.pathname)
       const id = solves.choosePuzzleId($puzzleCounts.hexagonalWrap[`${size}x${size}`])
-      await goto(`/hexagonal-wrap/${size}/${id}`)
+      await goto(`/hexagonal-wrap/${size}/${id}`, {replaceState: true})
   })
 </script>
 

--- a/src/routes/hexagonal-wrap/index.svelte
+++ b/src/routes/hexagonal-wrap/index.svelte
@@ -3,7 +3,7 @@
   import {goto} from '$app/navigation'
 
   onMount(async () => {
-      await goto(`/hexagonal-wrap/5`)
+      await goto(`/hexagonal-wrap/5`, {replaceState: true})
   })
 </script>
 <div class="container">

--- a/src/routes/hexagonal/[size=integer]/[id=integer].svelte
+++ b/src/routes/hexagonal/[size=integer]/[id=integer].svelte
@@ -104,8 +104,9 @@
   }
 
   function saveProgress(event) {
-    const data = JSON.stringify(event.detail)
-    window.localStorage.setItem(progressStoreName, data)
+    const {data, name} = event.detail
+    const dataStr = JSON.stringify(data)
+    window.localStorage.setItem(name, dataStr)
   }
 </script>
 
@@ -124,6 +125,7 @@
 
 {#key $page.params}
   <Puzzle {width} {height} {tiles} {savedProgress}
+     {progressStoreName}
      on:solved={stop}
      on:initialized={start}
      on:progress={saveProgress}

--- a/src/routes/hexagonal/[size=integer]/[id=integer].svelte
+++ b/src/routes/hexagonal/[size=integer]/[id=integer].svelte
@@ -25,7 +25,6 @@
 </script>
 
 <script>
-  import { onMount } from 'svelte'
   import { page } from '$app/stores';
   import { browser } from '$app/env';
   import Puzzle from '$lib/puzzle/Puzzle.svelte';
@@ -37,7 +36,11 @@
   export let tiles
   let solved = false
   let nextPuzzleId = 1
-  
+  let previousParams = {
+    size: "0",
+    id: "0",
+  }
+
   let solves // a store of puzzles solve times
   let stats // a store of puzzle time stats
 
@@ -56,6 +59,17 @@
 
 
   $: if (browser && $page.params) {
+    if ($page.params.size !== previousParams.size) {
+      // if a player used the back button 
+      // and went from puzzle of one size
+      // directly to a puzzle of another size
+      // then we need to update solves and stats
+      solves = getSolves($page.url.pathname)
+      stats = getStats($page.url.pathname)
+      start()
+    } else if ($page.params.id !== previousParams.id) {
+      start()
+    }
     solved = false
     const progress = window.localStorage.getItem(progressStoreName)
     if (progress !== null) {
@@ -65,21 +79,21 @@
     }
   }
 
-  onMount(() => {
-    solves = getSolves($page.url.pathname)
-    stats = getStats($page.url.pathname)
-    start()
-  });
-
   function start() {
-    // console.log('start')
+    previousParams.size = $page.params.size
+    previousParams.id = $page.params.id
     if (solves!==undefined) {
       solve = solves.reportStart(Number($page.params.id))
+    }
+    if (solve.elapsedTime !== -1) {
+      nextPuzzleId = solves.choosePuzzleId(
+        $puzzleCounts.hexagonal[`${$page.params.size}x${$page.params.size}`], 
+        Number($page.params.id)
+      )
     }
   }
 
   function stop() {
-    // console.log('stop')
     solved = true
     solve = solves.reportFinish(Number($page.params.id))
     nextPuzzleId = solves.choosePuzzleId(

--- a/src/routes/hexagonal/[size=integer]/index.svelte
+++ b/src/routes/hexagonal/[size=integer]/index.svelte
@@ -10,7 +10,7 @@
       const size = $page.params.size
       solves = getSolves($page.url.pathname)
       const id = solves.choosePuzzleId($puzzleCounts.hexagonal[`${size}x${size}`])
-      await goto(`/hexagonal/${size}/${id}`)
+      await goto(`/hexagonal/${size}/${id}`, {replaceState: true})
   })
 </script>
 

--- a/src/routes/hexagonal/index.svelte
+++ b/src/routes/hexagonal/index.svelte
@@ -3,7 +3,7 @@
   import {goto} from '$app/navigation'
 
   onMount(async () => {
-      await goto(`/hexagonal/5`)
+      await goto(`/hexagonal/5`, {replaceState: true})
   })
 </script>
 <div class="container">


### PR DESCRIPTION
Used `replaceState: true` on puzzle type and size page redirects.
Fixed a couple bugs that resulted from the possibility of direct navigation between puzzle pages.