### PR TITLE
Pause timer when tab is hidden

### DIFF
--- a/src/lib/Timer.svelte
+++ b/src/lib/Timer.svelte
@@ -25,6 +25,7 @@
 		puzzleId: -1,
 		startedAt: -1,
 		finishedAt: -1,
+		pausedAt: -1,
 		elapsedTime: -1,
 		error: null
 	};
@@ -60,7 +61,9 @@
 	{:else if solve.startedAt === -1}
 		Loading puzzle...
 	{:else if $settings.showTimer}
-		{#if solve.finishedAt === -1}
+		{#if solve.pausedAt !== -1}
+		  Paused
+		{:else if solve.finishedAt === -1}
 			Time: {formatTime(elapsed, false)} 
 		{:else}
 			You have solved the puzzle in {formatTime(elapsed, true)}

--- a/src/lib/puzzle/Puzzle.svelte
+++ b/src/lib/puzzle/Puzzle.svelte
@@ -53,7 +53,6 @@
     onMount(()=>{
         game.initializeBoard()
         resize(innerWidth, innerHeight)
-        console.log('dispatching initialized')
         dispatch('initialized')
     })
 
@@ -62,7 +61,6 @@
         save.clear()
         if (!$solved) {
             save.now()
-            console.log('dispatching pause')
             dispatch('pause')
         }
     })

--- a/src/lib/puzzle/Puzzle.svelte
+++ b/src/lib/puzzle/Puzzle.svelte
@@ -53,13 +53,18 @@
     onMount(()=>{
         game.initializeBoard()
         resize(innerWidth, innerHeight)
+        console.log('dispatching initialized')
         dispatch('initialized')
     })
 
     onDestroy(()=>{
         // save progress immediately if navigating away (?)
         save.clear()
-        if (!$solved) {save.now()}
+        if (!$solved) {
+            save.now()
+            console.log('dispatching pause')
+            dispatch('pause')
+        }
     })
 
     function createThrottle(callback, timeout) {

--- a/src/lib/puzzleWrapper/PuzzleWrapper.svelte
+++ b/src/lib/puzzleWrapper/PuzzleWrapper.svelte
@@ -7,6 +7,7 @@
 	import Timer from '$lib/Timer.svelte';
 	import Stats from '$lib/Stats.svelte';
 	import { getSolves, getStats } from '$lib/stores';
+  import { onMount } from 'svelte';
 
 	/** @type {'hexagonal'|'hexagonal-wrap'} */
 	export let category;
@@ -46,6 +47,7 @@
 		puzzleId: -1,
 		startedAt: -1,
 		finishedAt: -1,
+		pausedAt: -1,
 		elapsedTime: -1
 	};
 	/** @type {import('$lib/puzzle/Puzzle.svelte').default}*/
@@ -53,6 +55,7 @@
 
 	$: if (browser && $page.params) {
 		if (size !== previousParams.size) {
+			solves?.pause(previousParams.id);
 			// if a player used the back button
 			// and went from puzzle of one size
 			// directly to a puzzle of another size
@@ -61,6 +64,7 @@
 			stats = getStats(pathname);
 			start();
 		} else if (puzzleId !== previousParams.id) {
+			solves?.pause(previousParams.id);
 			start();
 		}
 		solved = false;
@@ -101,6 +105,21 @@
 	function newPuzzle() {
 		goto(`/${category}/${size}/${nextPuzzleId}`);
 	}
+
+	onMount(() => {
+		function handleVisibilityChange(e) {
+			console.log(`got event: ${document.visibilityState}`)
+			if (document.visibilityState === 'visible') {
+				solve = solves.unpause(puzzleId);
+			} else {
+				solve = solves.pause(puzzleId);
+			}
+		}
+
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+		return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+	});
+
 </script>
 
 {#key `/${category}/${size}/${puzzleId}`}

--- a/src/lib/puzzleWrapper/PuzzleWrapper.svelte
+++ b/src/lib/puzzleWrapper/PuzzleWrapper.svelte
@@ -56,7 +56,7 @@
 	$: if (browser && $page.params) {
 		if (size !== previousParams.size) {
 			if (previousParams.size) {
-				console.log('changed size, pausing', previousParams.id)
+				// console.log('changed size, pausing', previousParams.id)
 				solves?.pause(previousParams.id);
 			}
 			// if a player used the back button
@@ -67,7 +67,7 @@
 			stats = getStats(pathname);
 		} else if (puzzleId !== previousParams.id) {
 			if (previousParams.id) {
-				console.log('changed id, pausing', previousParams.id)
+				// console.log('changed id, pausing', previousParams.id)
 				solves?.pause(previousParams.id);
 			}
 		}
@@ -81,7 +81,6 @@
 	}
 
 	function start() {
-		console.log('Starting', puzzleId)
 		previousParams.size = size;
 		previousParams.id = puzzleId;
 		if (solves !== undefined) {
@@ -113,7 +112,7 @@
 
 	onMount(() => {
 		function handleVisibilityChange(e) {
-			console.log(`got event: ${document.visibilityState}`)
+			// console.log(`got visibility change event: ${document.visibilityState}`)
 			if (document.visibilityState === 'visible') {
 				solve = solves.unpause(puzzleId);
 			} else {

--- a/src/lib/puzzleWrapper/PuzzleWrapper.svelte
+++ b/src/lib/puzzleWrapper/PuzzleWrapper.svelte
@@ -55,17 +55,21 @@
 
 	$: if (browser && $page.params) {
 		if (size !== previousParams.size) {
-			solves?.pause(previousParams.id);
+			if (previousParams.size) {
+				console.log('changed size, pausing', previousParams.id)
+				solves?.pause(previousParams.id);
+			}
 			// if a player used the back button
 			// and went from puzzle of one size
 			// directly to a puzzle of another size
 			// then we need to update solves and stats
 			solves = getSolves(pathname);
 			stats = getStats(pathname);
-			start();
 		} else if (puzzleId !== previousParams.id) {
-			solves?.pause(previousParams.id);
-			start();
+			if (previousParams.id) {
+				console.log('changed id, pausing', previousParams.id)
+				solves?.pause(previousParams.id);
+			}
 		}
 		solved = false;
 		const progress = window.localStorage.getItem(progressStoreName);
@@ -77,6 +81,7 @@
 	}
 
 	function start() {
+		console.log('Starting', puzzleId)
 		previousParams.size = size;
 		previousParams.id = puzzleId;
 		if (solves !== undefined) {
@@ -134,6 +139,7 @@
 		on:solved={stop}
 		on:initialized={start}
 		on:progress={saveProgress}
+		on:pause={() => solves.pause(puzzleId)}
 	/>
 {/key}
 

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -242,14 +242,14 @@ function createSolvesStore(path) {
 
 	// adds a pausedAt time to a puzzle if the puzzle is running and not paused
     function pause(puzzleId) {
-		console.log('pausing', puzzleId)
+		// console.log('pausing', puzzleId)
         let solve;
         update(solves => {
             // find if this puzzle is in progress
             solve = solves.find(solve => solve.puzzleId === puzzleId);
             if (solve !== undefined && solve.startedAt !== -1 && solve.elapsedTime === -1 && solve.pausedAt === -1) {
                 solve.pausedAt = (new Date()).valueOf();
-				console.log('paused', puzzleId)
+				// console.log('paused', puzzleId)
             }
             return solves
         });
@@ -258,7 +258,7 @@ function createSolvesStore(path) {
 
 	// removes pausedAt and adjusts startedAt if the puzzle is paused
     function unpause(puzzleId) {
-        console.log('unpausing', puzzleId);
+        // console.log('unpausing', puzzleId);
         let solve;
         update(solves => {
             // find if this puzzle in in progress and paused
@@ -267,7 +267,7 @@ function createSolvesStore(path) {
                 const now = (new Date()).valueOf();
                 const pausedElapsedTime = now - solve.pausedAt;
                 solve.pausedAt = -1; // clear paused time
-				console.log('unpaused', puzzleId)
+				// console.log('unpaused', puzzleId)
 
                 // guard against unexpected quirks like setting clock back
                 if (pausedElapsedTime >= 0) {

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -240,29 +240,34 @@ function createSolvesStore(path) {
         return solve
     }
 
+	// adds a pausedAt time to a puzzle if the puzzle is running and not paused
     function pause(puzzleId) {
+		console.log('pausing', puzzleId)
         let solve;
         update(solves => {
             // find if this puzzle is in progress
             solve = solves.find(solve => solve.puzzleId === puzzleId);
-            if (solve !== undefined && solve.startedAt !== -1 && solve.elapsedTime === -1) {
+            if (solve !== undefined && solve.startedAt !== -1 && solve.elapsedTime === -1 && solve.pausedAt === -1) {
                 solve.pausedAt = (new Date()).valueOf();
+				console.log('paused', puzzleId)
             }
             return solves
         });
         return solve;
     }
 
+	// removes pausedAt and adjusts startedAt if the puzzle is paused
     function unpause(puzzleId) {
+        console.log('unpausing', puzzleId);
         let solve;
-        console.log(`unpausing ${puzzleId}`);
         update(solves => {
-            // find if this puzzle in in progress
+            // find if this puzzle in in progress and paused
             solve = solves.find(solve => solve.puzzleId === puzzleId);
             if (solve !== undefined && solve.startedAt !== -1 && solve.elapsedTime === -1 && solve.pausedAt > solve.startedAt) {
                 const now = (new Date()).valueOf();
                 const pausedElapsedTime = now - solve.pausedAt;
                 solve.pausedAt = -1; // clear paused time
+				console.log('unpaused', puzzleId)
 
                 // guard against unexpected quirks like setting clock back
                 if (pausedElapsedTime >= 0) {


### PR DESCRIPTION
Resolves #35. Regarding the last comment, I believe `visibilitychange` [covers](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event) every relevant case:

> This event fires with a visibilityState of hidden when a user navigates to a new page, switches tabs, closes the tab, minimizes or closes the browser, or, on mobile, switches from the browser to a different app. Transitioning to hidden is the last event that's reliably observable by the page, so developers should treat it as the likely end of the user's session (for example, for sending analytics data).

I got pausing timers working in Safari and Chrome. I noticed a small thing, not a blocker—when you're working on a puzzle of one size and click a link to load a puzzle of a new size, the current puzzle won't be paused, I'm confused why. After that though, the back and forward buttons pause and unpause the puzzles correctly. But for every other case I tested, it worked like a charm!

Please let me know if it would be helpful to make any changes. Thanks!