### PR TITLE
A setting to disable zoom/pan

### DIFF
--- a/src/lib/puzzle/Puzzle.svelte
+++ b/src/lib/puzzle/Puzzle.svelte
@@ -50,14 +50,17 @@
         // take full width without scroll bar
         const maxPixelWidth = innerWidth - 18
         // take most height, leave some for scrolling the page on mobile
-        const maxPixelHeight = Math.round(0.8*innerHeight)
+        const maxPixelHeight = $settings.disableZoomPan ? innerHeight : Math.round(0.8*innerHeight)
 
         const maxGridWidth = grid.XMAX - grid.XMIN
         const maxGridHeight = grid.YMAX - grid.YMIN
 
         const wpx = maxPixelWidth / maxGridWidth
         const hpx = maxPixelHeight / maxGridHeight
-        const pxPerCell = Math.max(60, Math.min(100, wpx, hpx))
+        let pxPerCell = Math.min(100, wpx, hpx)
+        if (!($settings.disableZoomPan)) {
+            pxPerCell = Math.max(60, pxPerCell)
+        }
         if (wrap) {
             svgWidth = Math.min(maxPixelWidth, pxPerCell * maxGridWidth)
         } else {
@@ -76,6 +79,10 @@
     }
 
     function resize() {
+        if ($settings.disableZoomPan) {
+            // do nothing to let browser zoom handle it all
+            return
+        }
         const pxPerCell = svgWidth / $viewBox.width
         // take full width without scroll bar
         const maxPixelWidth = innerWidth - 18

--- a/src/lib/puzzleWrapper/PuzzleWrapper.svelte
+++ b/src/lib/puzzleWrapper/PuzzleWrapper.svelte
@@ -106,7 +106,7 @@
 	}
 
 	function newPuzzle() {
-		goto(`/${category}/${size}/${nextPuzzleId}`);
+		goto(`/${category}/${size}/${nextPuzzleId}`, {noscroll: true});
 	}
 
 	onMount(() => {
@@ -147,7 +147,7 @@
 			{#if solved}
 				Solved!
 			{/if}
-			<a href="/{category}/{size}/{nextPuzzleId}">Next puzzle</a>
+			<a href="/{category}/{size}/{nextPuzzleId}" sveltekit:noscroll>Next puzzle</a>
 		{/if}
 	</div>
 	<PuzzleButtons

--- a/src/lib/settings/Settings.svelte
+++ b/src/lib/settings/Settings.svelte
@@ -71,6 +71,18 @@ onMount(()=>{
         </label>
         </div>
     </div>
+    <div class="controlMode">
+        <h3>Zoom and pan</h3>
+        <p>If you find current zoom and pan functions uncomfortable you can disable them. Puzzles will be shown fully zoomed out. You can rely on browser zoom to deal with small tiles.</p>
+        <label>
+            <input type=checkbox 
+                bind:checked={$settings.disableZoomPan} 
+                name="disableZoomPan" 
+                >
+                Disable zooming and panning
+        </label>
+        <p>Please <strong>refresh the page</strong> for the changes to take effect.</p>
+    </div>
     {/if}
 </div>
 

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -30,6 +30,7 @@ export const puzzleCounts = writable({
  * @property {ControlMode} controlMode
  * @property {Boolean} invertRotationDirection
  * @property {Boolean} showTimer
+ * @property {Boolean} disableZoomPan
  */
 
 function createSettings() {
@@ -38,6 +39,7 @@ function createSettings() {
         controlMode: 'rotate_lock',
         invertRotationDirection: false,
         showTimer: true,
+        disableZoomPan: false,
     }
 
 	const { subscribe, set, update } = writable(defaultSettings);

--- a/src/routes/hexagonal-wrap/[size=integer]/[id=integer].svelte
+++ b/src/routes/hexagonal-wrap/[size=integer]/[id=integer].svelte
@@ -47,10 +47,7 @@
 <div class="info container">
   <h2> {$page.params.size}x{$page.params.size} Hexagonal Wrap Pipes Puzzle #{$page.params.id}</h2>
   
-  <p>Rotate the tiles so that all pipes are connected with no loops. The puzzle wraps around and connects back to itself - left to right and top to bottom.</p>
-
-  <p> 
-    Multiple copies of tiles are shown to help you solve. Use mouse wheel to zoom in/out.</p>
+  <p>Rotate the tiles so that all pipes are connected with no loops. The puzzle wraps around and connects back to itself - left to right and top to bottom. Multiple copies of tiles are shown to help you solve. </p>
 </div>
 
 <PuzzleWrapper

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -70,6 +70,13 @@ on:solved={()=>hexWrapSolved = true}
 <h2> Changelog </h2>
 <ul>
     <li>
+        <em>2022-08-15</em>
+        <ul>
+            <li>Added a setting to disable zoom/pan because the new functions weren't working well for some users. If you use the setting then puzzles will be shown fully zoomed out like before and you can rely on browser zoom to deal with small tiles.</li>
+            <li>As a small improvement made the page keep scroll position the same when you click "Next puzzle".</li>
+        </ul> 
+    </li>
+    <li>
         <em>2022-08-13</em> The timer now stops ticking when you leave the puzzle page or switch to a different tab. It continues when you return to the puzzle. This should give more accurate times on large puzzles. Thanks to <a href="https://github.com/joshwilsonvu" target="_blank" rel="noopener">@joshwilsonvu</a> for the pull request.
     </li>
     <li><em>2022-08-11</em> Zoom and pan! Solving big puzzles should be easier now with the ability to zoom in and move around. 


### PR DESCRIPTION
Close #40 - adds a setting to disable pan/zoom functions. Let browser zoom deal with too small tiles.