### PR TITLE
Consider making daily puzzles start at midnight in the local timezone

### DIFF
--- a/src/routes/daily/+page.js
+++ b/src/routes/daily/+page.js
@@ -2,10 +2,10 @@ import { error } from '@sveltejs/kit';
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch }) {
-	const today = new Date().toISOString();
-	const year = today.slice(0, 4);
-	const month = today.slice(5, 7);
-	const day = today.slice(8, 10);
+	const today = new Date();
+	const year = today.getFullYear().toString().padStart(4, '0');
+	const month = (today.getMonth() + 1).toString().padStart(2, '0');
+	const day = today.getDate().toString().padStart(2, '0');
 	const url = `/_instances/daily/${year}/${month}/${day}.json`;
 	const response = await fetch(url);
 

--- a/src/routes/daily/+page.svelte
+++ b/src/routes/daily/+page.svelte
@@ -29,7 +29,7 @@
 	let savedProgress = undefined;
 	let shareText = '';
 
-	const nextPuzzleAt = new Date(data.date).valueOf() + 24 * 60 * 60 * 1000;
+	const nextPuzzleAt = new Date(data.date).valueOf() + (new Date().getTimezoneOffset() * 60 * 1000) + 24 * 60 * 60 * 1000;
 	function formatTimeLeft() {
 		const now = new Date().valueOf();
 		const delta = nextPuzzleAt - now;


### PR DESCRIPTION
Currently the UTC time is used.

I tried solving this, but I'm not too familiar with svelte. (and, side note, vanilla js dates make me sad)

One downside with this approach: this will server-render the data for the UTC game, but the client may need a different date, leading to an extra fetch for the local timezone's game upon load.