### PR TITLE
Add extra settings for puzzle rules

### DIFF
--- a/src/lib/puzzle/game.js
+++ b/src/lib/puzzle/game.js
@@ -324,10 +324,12 @@ export function PipesGame(grid, tiles, savedProgress) {
 			return;
 		}
 		const tileState = self.tileStates[tileIndex];
-		if (tileState.data.edgeMarks[index] === mark) {
-			tileState.data.edgeMarks[index] = 'empty';
-		} else if (tileState.data.edgeMarks[index] !== 'none') {
-			tileState.data.edgeMarks[index] = mark;
+		if (tileState.data.edgeMarks[index] !== 'none') {
+			if (tileState.data.edgeMarks[index] === mark || mark === 'empty') {
+				tileState.data.edgeMarks[index] = 'empty';
+			} else {
+				tileState.data.edgeMarks[index] = mark;
+			}
 		}
 		tileState.set(tileState.data);
 		if (tileState.data.edgeMarks[index] !== 'empty' && assistant) {
@@ -592,6 +594,11 @@ export function PipesGame(grid, tiles, savedProgress) {
 		}
 		if (tileState.data.locked !== targetState) {
 			tileState.toggleLocked();
+		}
+		if (targetState && currentSettings.removeEdgeMarksOnLock) {
+			for (const direction of grid.DIRECTIONS) {
+				self.toggleEdgeMark('empty', tileIndex, direction, assistant)
+			}
 		}
 		if (targetState && assistant) {
 			for (let direction of self.grid.DIRECTIONS) {

--- a/src/lib/settings/Settings.svelte
+++ b/src/lib/settings/Settings.svelte
@@ -62,15 +62,16 @@
 					<li>Right click / long press - lock tile</li>
 				</ul>
 			{/if}
-			<label>
-				<input
-					type="checkbox"
-					bind:checked={$settings.invertRotationDirection}
-					name="invertRotationDirection"
-				/>
-				Invert rotation direction
-			</label>
 		</div>
+		<label>
+			<input
+				type="checkbox"
+				bind:checked={$settings.invertRotationDirection}
+				name="invertRotationDirection"
+			/>
+			Invert rotation direction
+		</label>
+		<br />
 		<label>
 			<input type="checkbox" bind:checked={$settings.assistant} name="assistant" />
 			Use smart assistant. When you lock a tile or create an edgemark surrounding tiles will rotate to

--- a/src/lib/settings/Settings.svelte
+++ b/src/lib/settings/Settings.svelte
@@ -82,6 +82,11 @@
 			<input type="checkbox" bind:checked={$settings.requireLocked} name="requireLocked" />
 			Require all tiles to be locked for a level to be considered solved
 		</label>
+		<br />
+		<label>
+			<input type="checkbox" bind:checked={$settings.removeEdgeMarksOnLock} name="removeEdgeMarksOnLock" />
+			Remove a tile's edge marks when it is locked
+		</label>
 	</div>
 	<div class="controlMode">
 		<h3>Timer</h3>

--- a/src/lib/settings/Settings.svelte
+++ b/src/lib/settings/Settings.svelte
@@ -77,6 +77,11 @@
 			Use smart assistant. When you lock a tile or create an edgemark surrounding tiles will rotate to
 			match.
 		</label>
+		<br />
+		<label>
+			<input type="checkbox" bind:checked={$settings.requireLocked} name="requireLocked" />
+			Require all tiles to be locked for a level to be considered solved
+		</label>
 	</div>
 	<div class="controlMode">
 		<h3>Timer</h3>

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -41,7 +41,8 @@ function createSettings() {
 		invertRotationDirection: false,
 		showTimer: true,
 		disableZoomPan: false,
-		assistant: false
+		assistant: false,
+		requireLocked: false
 	};
 
 	const { subscribe, set, update } = writable(defaultSettings);

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -42,7 +42,8 @@ function createSettings() {
 		showTimer: true,
 		disableZoomPan: false,
 		assistant: false,
-		requireLocked: false
+		requireLocked: false,
+		removeEdgeMarksOnLock: false
 	};
 
 	const { subscribe, set, update } = writable(defaultSettings);


### PR DESCRIPTION
Adds two additional settings that affect the puzzle rules:

- Require all tiles to be locked for the game to be considered solved (I personally like systematically solving every tile, so want to be able to confirm that, even if the puzzle ends up in a solved state).
- Remove all edge marks on a tile when it is locked (most of the time I remove edge marks from locked tiles to keep the board tidier).