### PR TITLE
Save the state of the daily puzzle when completed

### DIFF
--- a/src/lib/puzzle/Puzzle.svelte
+++ b/src/lib/puzzle/Puzzle.svelte
@@ -17,6 +17,7 @@
 	/** @type {Number|undefined} */
 	export let preferredPxPerCell = undefined;
 	export let showSolveButton = false;
+	export let saveSolved = false;
 	export let animate = false;
 
 	// Remember the name that the puzzle was created with
@@ -155,7 +156,7 @@
 	}
 
 	function saveProgress() {
-		if ($solved) {
+		if ($solved && !saveSolved) {
 			return;
 		}
 		const tileStates = game.tileStates.map((tile) => {

--- a/src/routes/daily/+page.svelte
+++ b/src/routes/daily/+page.svelte
@@ -157,6 +157,7 @@
 <Puzzle
 	{grid}
 	tiles={data.tiles}
+	saveSolved={true}
 	{savedProgress}
 	{progressStoreName}
 	bind:this={puzzle}


### PR DESCRIPTION
I've noticed that if you come back to the daily when you've already solved it, it hasn't saved the completed state, but instead a few tiles tend to not be completed. This looks to fix that, but I'm not completely sure it won't introduce any other issues.