### PR TITLE
Add settings for controlling pan and zoom

### DIFF
--- a/src/lib/puzzle/controls.js
+++ b/src/lib/puzzle/controls.js
@@ -119,7 +119,10 @@ export function controls(node, game) {
 		if (mouseDownOrigin.tileIndex === -1) {
 			if (!useZoomPan) {
 				state = 'idle';
-			} else if (!grid.wrap && (x < grid.XMIN || x > grid.XMAX || y < grid.YMIN || y > grid.YMAX)) {
+			} else if (
+				!grid.wrap && !currentSettings.allowEmptySpacePan &&
+				(x < grid.XMIN || x > grid.XMAX || y < grid.YMIN || y > grid.YMAX)
+			) {
 				state = 'idle';
 			} else {
 				state = 'panning';
@@ -313,7 +316,10 @@ export function controls(node, game) {
 	 */
 	function handleWheel(event) {
 		const [x, y] = getEventCoordinates(event);
-		if (!grid.wrap && (x < grid.XMIN || x > grid.XMAX || y < grid.YMIN || y > grid.YMAX)) {
+		if (
+			!grid.wrap && !currentSettings.allowEmptySpacePan &&
+			(x < grid.XMIN || x > grid.XMAX || y < grid.YMIN || y > grid.YMAX)
+		) {
 			// allow scrolling when the mouse is over empty space
 			return;
 		}
@@ -419,7 +425,7 @@ export function controls(node, game) {
 				if (!useZoomPan) {
 					touchState = 'idle';
 				} else if (
-					!grid.wrap &&
+					!grid.wrap && !currentSettings.allowEmptySpacePan &&
 					(x < grid.XMIN || x > grid.XMAX || y < grid.YMIN || y > grid.YMAX)
 				) {
 					touchState = 'idle';

--- a/src/lib/puzzle/controls.js
+++ b/src/lib/puzzle/controls.js
@@ -327,7 +327,7 @@ export function controls(node, game) {
 				// pan with 2-finger slides on touchpad
 				const dx = (normalized.pixelX / pixelsWidth) * viewBox.width;
 				const dy = (normalized.pixelY / pixelsHeight) * viewBox.height;
-				const sensitivity = 0.5;
+				const sensitivity = 0.5 * currentSettings.touchpadPanSensitivity / 100;
 				game.viewBox.pan(-dx * sensitivity, -dy * sensitivity);
 			}
 		} else {

--- a/src/lib/puzzle/controls.js
+++ b/src/lib/puzzle/controls.js
@@ -41,6 +41,7 @@ export function controls(node, game) {
 	// set this once to not deal with changes
 	// changes will take effect on page refresh
 	const useZoomPan = !currentSettings.disableZoomPan;
+	const useScrollZoomPan = !currentSettings.disableScrollZoomPan;
 
 	const rect = node.getBoundingClientRect();
 	const pixelsWidth = rect.width;
@@ -598,7 +599,7 @@ export function controls(node, game) {
 	document.addEventListener('mouseup', handleMouseUp);
 	document.addEventListener('keydown', handleKeyDown);
 	document.addEventListener('keyup', handleKeyUp);
-	if (useZoomPan) {
+	if (useScrollZoomPan) {
 		node.addEventListener('wheel', handleWheel, { passive: false });
 	}
 

--- a/src/lib/settings/Settings.svelte
+++ b/src/lib/settings/Settings.svelte
@@ -62,15 +62,16 @@
 					<li>Right click / long press - lock tile</li>
 				</ul>
 			{/if}
-			<label>
-				<input
-					type="checkbox"
-					bind:checked={$settings.invertRotationDirection}
-					name="invertRotationDirection"
-				/>
-				Invert rotation direction
-			</label>
 		</div>
+		<label>
+			<input
+				type="checkbox"
+				bind:checked={$settings.invertRotationDirection}
+				name="invertRotationDirection"
+			/>
+			Invert rotation direction
+		</label>
+		<br />
 		<label>
 			<input type="checkbox" bind:checked={$settings.assistant} name="assistant" />
 			Use smart assistant. When you lock a tile or create an edgemark surrounding tiles will rotate to

--- a/src/lib/settings/Settings.svelte
+++ b/src/lib/settings/Settings.svelte
@@ -87,6 +87,10 @@
 	</div>
 	<div class="controlMode">
 		<h3>Zoom and pan</h3>
+		<label>
+			Sensitivity when panning with a touchpad
+			<input type="range" min="1" max="200" bind:value={$settings.touchpadPanSensitivity} name="touchpadPanSensitivity" />
+		</label>
 		<p>
 			If you find current zoom and pan functions uncomfortable you can disable them. Puzzles will be
 			shown fully zoomed out. You can rely on browser zoom to deal with small tiles.

--- a/src/lib/settings/Settings.svelte
+++ b/src/lib/settings/Settings.svelte
@@ -95,6 +95,11 @@
 			<input type="checkbox" bind:checked={$settings.disableZoomPan} name="disableZoomPan" />
 			Disable zooming and panning
 		</label>
+		<br />
+		<label>
+			<input type="checkbox" bind:checked={$settings.disableScrollZoomPan} name="disableScrollZoomPan" />
+			Disable zooming and panning using the mouse wheel or touchpad
+		</label>
 		<p>Please <strong>refresh the page</strong> for the changes to take effect.</p>
 	</div>
 	<div class="animationSpeed">

--- a/src/lib/settings/Settings.svelte
+++ b/src/lib/settings/Settings.svelte
@@ -91,6 +91,11 @@
 			Sensitivity when panning with a touchpad
 			<input type="range" min="1" max="200" bind:value={$settings.touchpadPanSensitivity} name="touchpadPanSensitivity" />
 		</label>
+		<br />
+		<label>
+			<input type="checkbox" bind:checked={$settings.allowEmptySpacePan} name="allowEmptySpacePan" />
+			Allow panning while mouse is over empty space
+		</label>
 		<p>
 			If you find current zoom and pan functions uncomfortable you can disable them. Puzzles will be
 			shown fully zoomed out. You can rely on browser zoom to deal with small tiles.

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -44,6 +44,7 @@ function createSettings() {
 		controlMode: 'rotate_lock',
 		invertRotationDirection: false,
 		showTimer: true,
+		touchpadPanSensitivity: 100,
 		disableZoomPan: false,
 		disableScrollZoomPan: false,
 		assistant: false,

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -45,6 +45,7 @@ function createSettings() {
 		invertRotationDirection: false,
 		showTimer: true,
 		touchpadPanSensitivity: 100,
+		allowEmptySpacePan: false,
 		disableZoomPan: false,
 		disableScrollZoomPan: false,
 		assistant: false,

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -45,6 +45,7 @@ function createSettings() {
 		invertRotationDirection: false,
 		showTimer: true,
 		disableZoomPan: false,
+		disableScrollZoomPan: false,
 		assistant: false,
 		/** @type {AnimationSpeed} */
 		animationSpeed: 'normal'


### PR DESCRIPTION
Adds a couple of extra settings for pan and zoom:

- Disable pan/zoom with mouse wheel/touchpad
- Invert pan direction on touchpad (this one is inverted for me on my MacBook)
- Adjust pan sensitivity on touchpad
- Allow panning even when cursor is over empty space