### PR TITLE
wip: clip pipes to tile polygons

### DIFF
--- a/src/lib/header/ExamplePuzzle.svelte
+++ b/src/lib/header/ExamplePuzzle.svelte
@@ -1,5 +1,6 @@
 <script>
 	import ExampleTile from '$lib/header/ExampleTile.svelte';
+	import ClipPolygon from '$lib/puzzle/ClipPolygon.svelte';
 
 	export let grid;
 	/** @type {Number[]} */
@@ -35,6 +36,15 @@
 		height={svgHeight}
 		viewBox="{viewBox.xmin} {viewBox.ymin} {viewBox.width} {viewBox.height}"
 	>
+		<defs>
+			{#each Array(grid.total) as _, index (index)}
+				<ClipPolygon
+					i={index}
+					id={[grid.KIND,'clip','path',index].join('-')}
+					grid={grid}
+				/>
+			{/each}
+		</defs>
 		{#each visibleTiles as visibleTile, i (visibleTile.key)}
 			<ExampleTile
 				{grid}

--- a/src/lib/header/ExampleTile.svelte
+++ b/src/lib/header/ExampleTile.svelte
@@ -31,7 +31,11 @@
 	/>
 
 	<!-- Pipe shape -->
-	<g class="pipe" style="transform: {tile_transform}">
+	<g
+		class="pipe"
+		style="transform: {tile_transform}"
+		clip-path="url(#{[grid.KIND,'clip','path',i].join('-')})"
+	>
 		<!-- Pipe outline -->
 		<path
 			d={path}

--- a/src/lib/puzzle/ClipPolygon.svelte
+++ b/src/lib/puzzle/ClipPolygon.svelte
@@ -1,0 +1,17 @@
+<script>
+    /** @type {Number} i*/
+    export let i;
+
+    /**
+     * @type {import('$lib/puzzle/game').PipesGame} game
+     */
+    export let game;
+    export let cx = 0;
+    export let cy = 0;
+</script>
+
+<clipPath id="clip-path-{i}">
+    <path
+        d={game.grid.getClipPath(i)}
+    />
+</clipPath>

--- a/src/lib/puzzle/ClipPolygon.svelte
+++ b/src/lib/puzzle/ClipPolygon.svelte
@@ -1,17 +1,16 @@
 <script>
     /** @type {Number} i*/
     export let i;
+    export let id;
 
     /**
      * @type {import('$lib/puzzle/game').PipesGame} game
      */
-    export let game;
-    export let cx = 0;
-    export let cy = 0;
+    export let grid;
 </script>
 
-<clipPath id="clip-path-{i}">
+<clipPath id="{id}">
     <path
-        d={game.grid.getClipPath(i)}
+        d={grid.getClipPath(i)}
     />
 </clipPath>

--- a/src/lib/puzzle/Puzzle.svelte
+++ b/src/lib/puzzle/Puzzle.svelte
@@ -332,12 +332,11 @@
 		on:save={save.soon}
 	>
 		<defs> 
-			{#each $visibleTiles as visibleTile, i (visibleTile.key)}
+			{#each Array(game.grid.total) as _, index (index)}
 				<ClipPolygon
-					i={visibleTile.index}
-					{game}
-					cx={visibleTile.x}
-					cy={visibleTile.y}
+					i={index}
+					id={'clip-path-' + index}
+					grid={game.grid}
 				/>
 			{/each}
 		</defs>

--- a/src/lib/puzzle/Puzzle.svelte
+++ b/src/lib/puzzle/Puzzle.svelte
@@ -2,6 +2,7 @@
 	import { settings } from '$lib/stores';
 	import { controls } from '$lib/puzzle/controls';
 	import Tile from '$lib/puzzle/Tile.svelte';
+	import ClipPolygon from '$lib/puzzle/ClipPolygon.svelte';
 	import { onMount, onDestroy, createEventDispatcher, tick } from 'svelte';
 	import { PipesGame } from '$lib/puzzle/game';
 	import { Solver } from './solver';
@@ -330,6 +331,16 @@
 		on:contextmenu|preventDefault={() => {}}
 		on:save={save.soon}
 	>
+		<defs> 
+			{#each $visibleTiles as visibleTile, i (visibleTile.key)}
+				<ClipPolygon
+					i={visibleTile.index}
+					{game}
+					cx={visibleTile.x}
+					cy={visibleTile.y}
+				/>
+			{/each}
+		</defs>
 		{#each $visibleTiles as visibleTile, i (visibleTile.key)}
 			<Tile
 				i={visibleTile.index}

--- a/src/lib/puzzle/Tile.svelte
+++ b/src/lib/puzzle/Tile.svelte
@@ -75,6 +75,7 @@
 	<g
 		class="pipe"
 		style="transform: {tile_transform} rotate({game.grid.getAngle($state.rotations, i)}rad)"
+		clip-path="url(#clip-path-{i})"
 	>
 		<!-- Pipe outline -->
 		<path

--- a/src/lib/puzzle/grids/abstractgrid.js
+++ b/src/lib/puzzle/grids/abstractgrid.js
@@ -160,6 +160,15 @@ export class AbstractGrid {
 	}
 
 	/**
+	 * Clipping path for svg pipes
+	 * @param {Number} index
+	 * @returns {String}
+	 */
+	getClipPath(index) {
+		return this.polygon_at(index).clip_path;
+	}
+
+	/**
 	 * Pipes lines path
 	 * @param {Number} tile
 	 * @param {Number} index

--- a/src/lib/puzzle/grids/polygonutils.js
+++ b/src/lib/puzzle/grids/polygonutils.js
@@ -92,14 +92,8 @@ export class RegularPolygonTile {
 		}
 
 		// draw tile contour
-		let angle = angle_offset - this.angle_unit / 2;
-		const r = this.radius_out - border_width;
-		this.contour_path = `m ${r * Math.cos(angle)} ${-r * Math.sin(angle)}`;
-		for (let i = 1; i <= this.num_directions; i++) {
-			angle += this.angle_unit;
-			this.contour_path += ` L ${r * Math.cos(angle)} ${-r * Math.sin(angle)}`;
-		}
-		this.contour_path += ' z';
+		this.contour_path = this.polygon_path(this.radius_out - border_width);
+		this.clip_path = this.polygon_path(this.radius_out + border_width/2);
 
 		// caches for frequently recomputed values
 		this.cache = {
@@ -109,6 +103,17 @@ export class RegularPolygonTile {
 			edgemark_line: new Map(),
 			wall_line: new Map()
 		};
+	}
+
+	polygon_path(r) {
+		let angle = this.angle_offset - this.angle_unit / 2;
+		let path = `m ${r * Math.cos(angle)} ${-r * Math.sin(angle)}`;
+		for (let i = 1; i <= this.num_directions; i++) {
+			angle += this.angle_unit;
+			path += ` L ${r * Math.cos(angle)} ${-r * Math.sin(angle)}`;
+		}
+		path += ' z';
+		return path;
 	}
 
 	/**
@@ -189,8 +194,9 @@ export class RegularPolygonTile {
 		this.directions.forEach((direction, index) => {
 			if ((direction & tile) > 0) {
 				const angle = this.angle_offset + this.angle_unit * index;
-				const dx = this.radius_in * Math.cos(angle);
-				const dy = this.radius_in * Math.sin(angle);
+				const radius = this.radius_in * 1.2;
+				const dx = radius * Math.cos(angle);
+				const dy = radius * Math.sin(angle);
 				path += ` l ${dx} ${-dy} L 0 0`;
 			}
 		});


### PR DESCRIPTION
This is a work-in-progress fix for #91 rendering glitches on iOS.

iOS does not draw line ends correctly for the purpose of drawing pipes, never mind when `stroke-linejoin` and/or transformations are involved. 

There were some proposed extensions to SVG to fix all this, but the advice I have read is that you can do most of what you want to do with [clipPath](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/clipPath).

So here is a first attempt. We generate the clip polygon the same as the tile path, except without subtracting `border_width` from the radius. Right now it is also adding half a border width to the radius because I was still seeing 1px of grey on iOS without it.

We also extend the pipes by 1.2 - probably more than needed, but we need a little stretch because iOS does not always draw all the way.

Before/after 📷 🧵  