### PR TITLE
fix: replace random per-component colors with single flow color

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"@tailwindcss/vite": "^4.2.2",
 		"cookie": "^0.4.1",
 		"normalize-wheel": "^1.0.1",
-		"randomcolor": "0.6.2",
 		"tailwindcss": "^4.2.2",
 		"transformation-matrix": "^2.15.0"
 	}

--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
 	"type": "module",
 	"dependencies": {
 		"@fontsource/fira-mono": "^4.5.0",
+		"@tailwindcss/vite": "^4.2.2",
 		"cookie": "^0.4.1",
 		"normalize-wheel": "^1.0.1",
 		"randomcolor": "0.6.2",
+		"tailwindcss": "^4.2.2",
 		"transformation-matrix": "^2.15.0"
 	}
 }

--- a/src/lib/puzzle/game.js
+++ b/src/lib/puzzle/game.js
@@ -1,6 +1,7 @@
-import randomColor from 'randomcolor';
 import { writable } from 'svelte/store';
 import { createViewBox } from './viewbox';
+
+const PIPE_COLOR = 'hsl(195,85%,72%)';
 
 /**
  * An edge mark
@@ -169,7 +170,7 @@ export function PipesGame(grid, tiles, savedProgress) {
 			return new StateStore({
 				tile: tiles[index],
 				rotations: savedTile.rotations,
-				color: savedTile.color,
+				color: savedTile.color === 'white' ? 'white' : PIPE_COLOR,
 				isPartOfLoop: false,
 				isPartOfIsland: false,
 				hasDisconnects: false,
@@ -695,7 +696,7 @@ export function PipesGame(grid, tiles, savedProgress) {
 				newColor = changedComponent.color;
 			}
 			if (newColor === 'white') {
-				newColor = randomColor({ luminosity: 'light' });
+				newColor = PIPE_COLOR;
 			}
 			if (constantComponent.color !== newColor) {
 				constantComponent.tiles.forEach((tileIndex) => {
@@ -769,7 +770,7 @@ export function PipesGame(grid, tiles, savedProgress) {
 		// const leaveTiles = fromIsBigger ? fromTiles : toTiles
 		const changeTiles = fromIsBigger ? toTiles : fromTiles;
 		const newComponent = {
-			color: randomColor({ luminosity: 'light' }),
+			color: 'white',
 			tiles: changeTiles,
 			/** @type {Set<Number>}*/
 			openEnds: new Set([])
@@ -782,6 +783,14 @@ export function PipesGame(grid, tiles, savedProgress) {
 				newComponent.openEnds.add(tileIndex);
 			}
 			self.tileStates[tileIndex].setColor(newComponent.color);
+		}
+
+		// Reset remaining component to white if it's now isolated (1 tile)
+		if (bigComponent.tiles.size <= 1) {
+			bigComponent.color = 'white';
+			for (let tileIndex of bigComponent.tiles) {
+				self.tileStates[tileIndex].setColor('white');
+			}
 		}
 		// console.log('created new component', newComponent.id, 'with tiles', [...changeTiles])
 	};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,10 @@
 // vite.config.js
 import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
 
 /** @type {import('vite').UserConfig} */
 const config = {
-	plugins: [sveltekit()],
+	plugins: [tailwindcss(), sveltekit()],
 	test: {
 		globals: true,
 		environment: 'jsdom'


### PR DESCRIPTION
Fixes #63

## Problem
The color picker occasionally assigned identical or perceptually similar colors to different connected pipe groups, making it hard to distinguish them.

## Solution
Replace the random per-component color system with a single accent color for all connected pipes. Color now serves as a binary connected/disconnected indicator rather than a group identifier.

## Behavior
- Tiles are white when isolated or disconnected
- Tiles turn blue when connected to at least one neighbor
- Tiles reset to white when disconnected

## Changes
- `src/lib/puzzle/game.js`: remove `randomcolor` dependency, add `PIPE_COLOR` constant, fix disconnect not resetting color, normalize saved progress colors on load

Also, the randomcolor package is still in package.json as a dependency even though it's no longer imported. Should be removed.

I'm working on other UI edits so i added some imports for tailwinds, which should probably be ignored if you don't mind. 